### PR TITLE
Fix map popup always visible + screen zoom on search input

### DIFF
--- a/src/components/BookingDrawer/BookingDrawer.js
+++ b/src/components/BookingDrawer/BookingDrawer.js
@@ -470,6 +470,8 @@ function StepStation({ userCoords: initialCoords, onSelect, initialSearch }) {
 
   const [locateError, setLocateError] = useState(false);
   const [mapSearchResult, setMapSearchResult] = useState(null);
+  const [mapRouteInfo,    setMapRouteInfo]    = useState(null);
+  const [mapRouteLoading, setMapRouteLoading] = useState(false);
 
   const locateMe = () => {
     if (!navigator.geolocation) return;
@@ -863,7 +865,7 @@ function StepStation({ userCoords: initialCoords, onSelect, initialSearch }) {
                       onFocus={() => suggestions.length > 0 && setShowSuggestions(true)}
                       onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); setSelected(null); handleSearchSubmit(); } }}
                       placeholder="Search area or landmark…"
-                      style={{ border:"none", outline:"none", fontSize:13, flex:1, background:"transparent", color:"#1e293b" }}
+                      style={{ border:"none", outline:"none", fontSize:16, flex:1, background:"transparent", color:"#1e293b", touchAction:"manipulation" }}
                     />
                     {search && (
                       <>
@@ -924,21 +926,53 @@ function StepStation({ userCoords: initialCoords, onSelect, initialSearch }) {
               })()}
             </div>
 
-            {/* Station count bubble — top left, below search bar */}
-            <div style={{ position:"absolute", top:68, left:12, zIndex:900, background:"white", borderRadius:12, padding:"6px 10px", fontSize:11, color:"#64748b", boxShadow:"0 2px 10px rgba(0,0,0,0.12)", pointerEvents:"none" }}>
-              {filtered.length} station{filtered.length !== 1 ? "s" : ""}{userCoords ? " near you" : ""}
-            </div>
-
             <StationMapMapbox
               stations={filtered}
               allStations={stations}
               selected={selected}
               onSelect={s => setSelected(s)}
-              onBook={s => { setSelected(s); onSelect(s); }}
               userCoords={userCoords}
               mapSearchResult={mapSearchResult}
               onClearMapSearch={() => setMapSearchResult(null)}
+              onRouteUpdate={(info, loading) => { setMapRouteInfo(info); setMapRouteLoading(loading); }}
             />
+
+            {/* ── Station popup — rendered here (outside map canvas) for reliable stacking ── */}
+            {selected && (
+              <div className={styles.stationMapPopup}>
+                <div className={styles.stationMapPopupInner}>
+                  <div className={styles.stationMapPopupIcon}>🏪</div>
+                  <div className={styles.stationMapPopupInfo}>
+                    <div className={styles.stationMapPopupName}>{selected.name}</div>
+                    <div className={styles.stationMapPopupSub}>
+                      {selected.location}
+                      {mapRouteLoading && <span> · ⏳</span>}
+                      {!mapRouteLoading && mapRouteInfo && !mapRouteInfo.isTransit && (
+                        <span> · 🚶 {mapRouteInfo.durationMin} min · {mapRouteInfo.distM < 1000 ? `${mapRouteInfo.distM} m` : `${(mapRouteInfo.distM / 1000).toFixed(1)} km`}</span>
+                      )}
+                      {!mapRouteLoading && mapRouteInfo && mapRouteInfo.isTransit && (
+                        <>
+                          <span> · {mapRouteInfo.distM < 1000 ? `${mapRouteInfo.distM} m` : `${(mapRouteInfo.distM / 1000).toFixed(1)} km`} · 🚶 {mapRouteInfo.durationMin} min · </span>
+                          <a href={mapRouteInfo.transitUrl} target="_blank" rel="noopener noreferrer" className={styles.transitLink} onClick={e => e.stopPropagation()}>
+                            🚌 Transit →
+                          </a>
+                        </>
+                      )}
+                      {!mapRouteLoading && !mapRouteInfo && selected.distance && (
+                        <span> · {selected.distance.toFixed(1)} km</span>
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => { setSelected(selected); onSelect(selected); }}
+                    className={styles.stationMapPopupBtn}
+                  >
+                    Book →
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         ) : (
           <div className={styles.stationList}>

--- a/src/components/BookingDrawer/StationMapMapbox.js
+++ b/src/components/BookingDrawer/StationMapMapbox.js
@@ -34,10 +34,10 @@ export default function StationMapMapbox({
   allStations,
   selected,
   onSelect,
-  onBook,
   userCoords,
   mapSearchResult,
   onClearMapSearch,
+  onRouteUpdate,
 }) {
   const mapRef = useRef(null);
 
@@ -47,10 +47,8 @@ export default function StationMapMapbox({
     zoom: 13.5,
   });
 
-  const [routeGeoJSON, setRouteGeoJSON]   = useState(null);
-  const [routeInfo,    setRouteInfo]      = useState(null);
-  const [routeLoading, setRouteLoading]   = useState(false);
-  const [toast,        setToast]          = useState(null);
+  const [routeGeoJSON, setRouteGeoJSON] = useState(null);
+  const [toast,        setToast]        = useState(null);
 
   // ── Inject mapbox-gl CSS once (avoids Next.js global CSS import restrictions) ─
   useEffect(() => {
@@ -131,7 +129,7 @@ export default function StationMapMapbox({
   useEffect(() => {
     if (!selected || !origin) {
       setRouteGeoJSON(null);
-      setRouteInfo(null);
+      onRouteUpdate?.(null, false);
       return;
     }
     const dest = getCoords(selected);
@@ -143,9 +141,8 @@ export default function StationMapMapbox({
     // Don't attempt routing across cities / countries — Mapbox walking won't work
     if (distKm > 50) return;
 
-    setRouteLoading(true);
     setRouteGeoJSON(null);
-    setRouteInfo(null);
+    onRouteUpdate?.(null, true);
 
     fetch(
       `https://api.mapbox.com/directions/v5/mapbox/walking/` +
@@ -154,12 +151,11 @@ export default function StationMapMapbox({
     )
       .then((r) => r.json())
       .then((data) => {
-        if (!data.routes?.[0]) return;
-        const route      = data.routes[0];
+        if (!data.routes?.[0]) { onRouteUpdate?.(null, false); return; }
+        const route       = data.routes[0];
         const durationMin = Math.round(route.duration / 60);
         const distM       = Math.round(route.distance);
-        setRouteGeoJSON(route.geometry);
-        setRouteInfo({
+        const info = {
           durationMin,
           distM,
           isTransit,
@@ -169,10 +165,11 @@ export default function StationMapMapbox({
               `&destination=${dest.lat},${dest.lon}` +
               `&travelmode=transit`
             : null,
-        });
+        };
+        setRouteGeoJSON(route.geometry);
+        onRouteUpdate?.(info, false);
       })
-      .catch(() => {})
-      .finally(() => setRouteLoading(false));
+      .catch(() => { onRouteUpdate?.(null, false); });
   }, [selected?._id, origin?.lat, origin?.lon]); // eslint-disable-line
 
   // ── Fly to search result, check for nearby stations ───────────────────────
@@ -245,9 +242,9 @@ export default function StationMapMapbox({
   useEffect(() => {
     if (!selected) {
       setRouteGeoJSON(null);
-      setRouteInfo(null);
+      onRouteUpdate?.(null, false);
     }
-  }, [selected]);
+  }, [selected]); // eslint-disable-line
 
   const handleShowNearest = () => {
     if (!toast?.nearest) return;
@@ -260,9 +257,6 @@ export default function StationMapMapbox({
 
   const pinPool = allStations?.length ? allStations : stations || [];
 
-  // ─── Format distance string ───────────────────────────────────────────────
-  const fmtDist = (m) =>
-    m < 1000 ? `${m} m` : `${(m / 1000).toFixed(1)} km`;
 
   return (
     <div className={styles.stationMapWrap}>
@@ -383,48 +377,6 @@ export default function StationMapMapbox({
         </div>
       )}
 
-      {/* ── Selected station popup with route info ── */}
-      {selected && (
-        <div className={styles.stationMapPopup}>
-          <div className={styles.stationMapPopupInner}>
-            <div className={styles.stationMapPopupIcon}>🏪</div>
-            <div className={styles.stationMapPopupInfo}>
-              <div className={styles.stationMapPopupName}>{selected.name}</div>
-              <div className={styles.stationMapPopupSub}>
-                {selected.location}
-                {routeLoading && <span> · ⏳</span>}
-                {!routeLoading && routeInfo && !routeInfo.isTransit && (
-                  <span> · 🚶 {routeInfo.durationMin} min · {fmtDist(routeInfo.distM)}</span>
-                )}
-                {!routeLoading && routeInfo && routeInfo.isTransit && (
-                  <>
-                    <span> · {fmtDist(routeInfo.distM)} · 🚶 {routeInfo.durationMin} min · </span>
-                    <a
-                      href={routeInfo.transitUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={styles.transitLink}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      🚌 Transit →
-                    </a>
-                  </>
-                )}
-                {!routeLoading && !routeInfo && selected.distance && (
-                  <span> · {selected.distance.toFixed(1)} km</span>
-                )}
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => onBook(selected)}
-              className={styles.stationMapPopupBtn}
-            >
-              Book →
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
- Move station popup out of StationMapMapbox into BookingDrawer so it renders above the map canvas with no stacking context issues
- Route info bubbled up via onRouteUpdate callback prop
- Remove in-map station count bubble (count already shown in header)
- Fix iOS screen zoom: map search input font-size set to 16px