### PR TITLE
Fix PWA Station schema error and auth race condition on navigation

### DIFF
--- a/src/app/api/partner/application/earnings/route.js
+++ b/src/app/api/partner/application/earnings/route.js
@@ -4,6 +4,7 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/dbConnect';
 import User from '@/models/User';
+import Station from '@/models/Station';
 import Booking from '@/models/booking';
 import BonusOffer from '@/models/BonusOffer';
 import PartnerBonus from '@/models/PartnerBonus';

--- a/src/app/api/partner/application/earnings/route.js
+++ b/src/app/api/partner/application/earnings/route.js
@@ -4,7 +4,7 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/dbConnect';
 import User from '@/models/User';
-import Station from '@/models/Station';
+import '@/models/Station'; // registers Station schema so populate('assignedStation') works
 import Booking from '@/models/booking';
 import BonusOffer from '@/models/BonusOffer';
 import PartnerBonus from '@/models/PartnerBonus';

--- a/src/app/partner/application/layout.js
+++ b/src/app/partner/application/layout.js
@@ -22,6 +22,7 @@ export default function PartnerAppLayout({ children }) {
       return;
     }
 
+    setIsLoading(true);
     const checkAuth = async () => {
       try {
         const response = await fetch('/api/auth/refresh', {


### PR DESCRIPTION
- earnings route: import Station model so populate('assignedStation') works in Vercel's isolated function context (model wasn't registered on cold start)
- PWA layout: setIsLoading(true) before each checkAuth call so child pages never start data fetches before the cookie refresh completes (fixes "Invalid or expired token" on tab navigation)