### PR TITLE
fix: wrap dbConnect inside try-catch in partner API routes

### DIFF
--- a/src/app/api/partner/[id]/bookings/route.js
+++ b/src/app/api/partner/[id]/bookings/route.js
@@ -42,15 +42,14 @@ async function verifyAdminOrSelf(req, userId) {
 }
 
 export async function GET(req, ctx) {
-  await dbConnect();
-  const { id: userId } = await getParams(ctx.params);
-
-  const auth = await verifyAdminOrSelf(req, userId);
-  if (auth.error) {
-    return NextResponse.json({ success: false, error: auth.error }, { status: auth.status });
-  }
-
   try {
+    await dbConnect();
+    const { id: userId } = await getParams(ctx.params);
+
+    const auth = await verifyAdminOrSelf(req, userId);
+    if (auth.error) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: auth.status });
+    }
     // 1) find partner & their station
     const user = await User.findById(userId).lean();
     if (!user?.assignedStation) {

--- a/src/app/api/partner/[id]/key-handovers/route.js
+++ b/src/app/api/partner/[id]/key-handovers/route.js
@@ -10,17 +10,16 @@ import { NextResponse } from 'next/server';
 const getParams = async (p) => (typeof p?.then === 'function' ? await p : p);
 
 export async function GET(req, ctx) {
-  await dbConnect();
-
-  // ✅ Works for both sync and async params
-  const { id: userId } = await getParams(ctx.params);
-
-  const token = req.headers.get('authorization')?.split(' ')[1];
-  if (!token) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-  }
-
   try {
+    await dbConnect();
+
+    const { id: userId } = await getParams(ctx.params);
+
+    const token = req.headers.get('authorization')?.split(' ')[1];
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     const decodedId = decoded.id || decoded.userId;
 
@@ -43,6 +42,9 @@ export async function GET(req, ctx) {
     return NextResponse.json({ success: true, handovers });
   } catch (err) {
     console.error('Key Handovers Fetch Error:', err);
+    if (err instanceof jwt.JsonWebTokenError) {
+      return NextResponse.json({ success: false, error: 'Invalid token' }, { status: 401 });
+    }
     return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/src/app/api/partner/[id]/station/route.js
+++ b/src/app/api/partner/[id]/station/route.js
@@ -8,16 +8,14 @@ import { NextResponse } from 'next/server';
 const getParams = async (p) => (typeof p?.then === 'function' ? await p : p);
 
 export async function GET(req, context) {
-  await dbConnect();
-
-  // ✅ await params (not context)
-  const { id: userId } = await getParams(context.params);
-
-  const authHeader = req.headers.get('authorization');
-  const token = authHeader?.startsWith('Bearer ') ? authHeader.split(' ')[1] : null;
-  if (!token) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-
   try {
+    await dbConnect();
+
+    const { id: userId } = await getParams(context.params);
+
+    const authHeader = req.headers.get('authorization');
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.split(' ')[1] : null;
+    if (!token) return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     const decodedId = decoded.id || decoded.userId; // tolerate either key
 


### PR DESCRIPTION
Prevents Vercel from returning a non-JSON crash page when dbConnect throws, which was breaking PWA history and partner dashboard data loading.