### PR TITLE
fix: partner dashboard bookings fetch uses cookie auth not Bearer token

### DIFF
--- a/src/app/partner/dashboard/page.js
+++ b/src/app/partner/dashboard/page.js
@@ -161,7 +161,7 @@ useEffect(() => {
         const stationData = await stationRes.json();
         if (stationRes.ok) setStation(stationData.station);
 
-        const bookingsRes = await fetch(`/api/partner/${userId}/bookings`, { headers: { Authorization: `Bearer ${token}` } });
+        const bookingsRes = await fetch(`/api/partner/${userId}/bookings`, { credentials: 'include' });
         const bookingsData = await bookingsRes.json();
         if (bookingsRes.ok) {
           const sorted = [...(bookingsData.bookings || [])].sort((a, b) => new Date(b.dropOffDate) - new Date(a.dropOffDate));


### PR DESCRIPTION
The bookings API uses HttpOnly cookie auth. The dashboard was sending Authorization header which was always rejected with 401.