### PR TITLE
feat: allow one partner to manage bookings across two stations

### DIFF
--- a/src/app/admin/dashboard/page.js
+++ b/src/app/admin/dashboard/page.js
@@ -346,6 +346,7 @@ const [editStation, setEditStation] = useState({
     is24Hours: false,
   });
   const [editStationCapacity, setEditStationCapacity] = useState(10);
+  const [editStationCoveredBy, setEditStationCoveredBy] = useState("");
 
   // UX states: months-first
   const [expandedMonth, setExpandedMonth] = useState(null); // month string like "November 2025"
@@ -490,6 +491,7 @@ useEffect(() => {
 
       setEditStationImages((selectedStation.images && selectedStation.images.join(", ")) || "");
       setEditStationCapacity(selectedStation.capacity || 10);
+      setEditStationCoveredBy(selectedStation.coveredByPartnerStation?._id || selectedStation.coveredByPartnerStation || "");
     }
     // include defaultDayTiming here so eslint won't complain that it's referenced above when creating timing defaults
   }, [selectedStation, allBookings, allKeyHandovers, defaultDayTiming]);
@@ -1115,6 +1117,7 @@ const getBookingAmount = (booking) => {
       },
       timings: { ...editStationTimings },
       capacity: editStationCapacity,
+      coveredByPartnerStation: editStationCoveredBy || null,
     };
 
     try {
@@ -2388,6 +2391,22 @@ Total: ${booking.luggageCount}
                       <input className={styles.input} value={editStation.latitude} onChange={(e) => setEditStation((s) => ({ ...s, latitude: e.target.value }))} placeholder="Latitude (e.g., -33.86)" />
                       <input className={styles.input} value={editStation.longitude} onChange={(e) => setEditStation((s) => ({ ...s, longitude: e.target.value }))} placeholder="Longitude (e.g., 151.20)" />
                       <input className={styles.input} value={editStationImages} onChange={(e) => setEditStationImages(e.target.value)} placeholder="Station images (optional) — comma separated URLs" />
+                    </div>
+                    <div style={{ marginTop: 12 }}>
+                      <label className={styles.label}>🔗 Physically managed by another station's partner (optional)</label>
+                      <select
+                        className={`${styles.input} ${styles.fullWidth}`}
+                        value={editStationCoveredBy}
+                        onChange={(e) => setEditStationCoveredBy(e.target.value)}
+                      >
+                        <option value="">— None (this station has its own partner) —</option>
+                        {stations.filter(s => s._id !== selectedStation._id).map(s => (
+                          <option key={s._id} value={s._id}>{s.name}</option>
+                        ))}
+                      </select>
+                      <p style={{ fontSize: 12, color: '#6b7280', marginTop: 4 }}>
+                        If set, the partner assigned to the selected station can also scan and manage bookings for this station.
+                      </p>
                     </div>
                   </div>
 

--- a/src/app/api/partner/application/confirm-dropoff/route.js
+++ b/src/app/api/partner/application/confirm-dropoff/route.js
@@ -4,6 +4,7 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/dbConnect';
 import Booking from '@/models/booking';
+import Station from '@/models/Station';
 import User from '@/models/User';
 import { verifyJWT } from '@/lib/auth';
 
@@ -70,7 +71,10 @@ export async function POST(request) {
       );
     }
 
-    if (booking.stationId.toString() !== partner.assignedStation.toString()) {
+    const coveredStations = await Station.find({ coveredByPartnerStation: partner.assignedStation }).select('_id').lean();
+    const validStationIds = [partner.assignedStation.toString(), ...coveredStations.map(s => s._id.toString())];
+
+    if (!validStationIds.includes(booking.stationId.toString())) {
       return NextResponse.json(
         { success: false, error: 'This booking is not for your station' },
         { status: 403 }

--- a/src/app/api/partner/application/today-bookings/route.js
+++ b/src/app/api/partner/application/today-bookings/route.js
@@ -4,6 +4,7 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/dbConnect';
 import Booking from '@/models/booking';
+import Station from '@/models/Station';
 import User from '@/models/User';
 import { verifyJWT } from '@/lib/auth';
 
@@ -56,6 +57,10 @@ export async function GET(request) {
 
     const stationId = partner.assignedStation;
 
+    // Include any stations whose bookings this partner physically manages
+    const coveredStations = await Station.find({ coveredByPartnerStation: stationId }).select('_id').lean();
+    const validStationIds = [stationId, ...coveredStations.map(s => s._id)];
+
     // 3. Calculate today's date range in Melbourne wall-clock UTC
     // Dates stored as fake-UTC (Melbourne wall-clock = UTC parts), so compare UTC midnight-to-midnight
     const melbParts = new Intl.DateTimeFormat('en-CA', {
@@ -74,7 +79,7 @@ export async function GET(request) {
 
     // 4. Find today's DROP-OFFS (status: pending or confirmed)
     const todayDropOffs = await Booking.find({
-      stationId,
+      stationId: { $in: validStationIds },
       dropOffDate: {
         $gte: todayStart,
         $lte: todayEnd
@@ -87,7 +92,7 @@ export async function GET(request) {
 
     // 5. Find today's PICK-UPS (status: stored)
     const todayPickUps = await Booking.find({
-      stationId,
+      stationId: { $in: validStationIds },
       pickUpDate: {
         $gte: todayStart,
         $lte: todayEnd

--- a/src/app/api/partner/application/verify-qr/route.js
+++ b/src/app/api/partner/application/verify-qr/route.js
@@ -82,17 +82,20 @@ export async function GET(request) {
       );
     }
 
-    // 6. Verify booking belongs to partner's station
+    // 6. Verify booking belongs to partner's station (or a station they cover)
     const bookingStationId = booking.stationId?._id || booking.stationId;
     const partnerStationId = partner.assignedStation;
 
-    if (bookingStationId.toString() !== partnerStationId.toString()) {
+    const coveredStations = await Station.find({ coveredByPartnerStation: partnerStationId }).select('_id').lean();
+    const validStationIds = [partnerStationId.toString(), ...coveredStations.map(s => s._id.toString())];
+
+    if (!validStationIds.includes(bookingStationId.toString())) {
       console.log('❌ Wrong station. Booking:', bookingStationId, 'Partner:', partnerStationId);
       return NextResponse.json(
-        { 
-          success: false, 
+        {
+          success: false,
           error: 'This booking is not for your station',
-          wrongStation: true 
+          wrongStation: true
         },
         { status: 403 }
       );

--- a/src/app/partner/application/scan/page.js
+++ b/src/app/partner/application/scan/page.js
@@ -427,7 +427,12 @@ export default function ScanPage() {
                     <span className={styles.detailLabel}>Booking Ref:</span>
                     <span className={styles.detailValue}>{bookingData.bookingReference}</span>
                   </div>
-                  
+
+                  <div className={styles.detailRow}>
+                    <span className={styles.detailLabel}>Station:</span>
+                    <span className={styles.detailValue}>{bookingData.stationName}</span>
+                  </div>
+
                   <div className={styles.detailRow}>
                     <span className={styles.detailLabel}>Customer:</span>
                     <span className={styles.detailValue}>{bookingData.fullName}</span>

--- a/src/models/Station.js
+++ b/src/models/Station.js
@@ -110,6 +110,13 @@ const StationSchema = new mongoose.Schema({
     ref: 'User'
   }],
 
+  // Station whose assigned partner physically manages this station's bookings
+  coveredByPartnerStation: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Station',
+    default: null
+  },
+
   rating: { 
     type: Number, 
     default: 4.8,


### PR DESCRIPTION
Adds station coverage model so a partner assigned to one station can scan and confirm bookings for a second station without switching logins. Configured per-station via a new coveredByPartnerStation field and an admin dashboard dropdown in the station edit form.